### PR TITLE
Fix prevention.create to use correct command type and log message

### DIFF
--- a/index.js
+++ b/index.js
@@ -1415,7 +1415,7 @@ class Turbot {
         // return self._watch("create", resource, filters.isArray() ? filters : [filters], action);
 
         const command = {
-          type: "rule_create",
+          type: "prevention_create",
           meta: {
             sourceResourceId,
           },
@@ -1427,7 +1427,7 @@ class Turbot {
 
         // command.meta = self.setCommandMeta(command.meta, {});
         command.payload = _.omitBy(command.payload, _.isNil);
-        let msg = `Rule created on resource ${sourceResourceId}`;
+        let msg = `Prevention created on resource ${sourceResourceId}`;
         self.log.info(msg, { data: command.payload.data });
         self._command(command);
 


### PR DESCRIPTION
## Summary

- Fix `prevention.create` to use command type `prevention_create` instead of `rule_create`
- Fix log message from `"Rule created on resource"` to `"Prevention created on resource"`

## Context

When `turbot.prevention.create()` was added in #78, the implementation was copied from the deprecated `turbot.rule.create()` method. The `update` and `delete` methods were properly updated to use `prevention_update`/`prevention_delete` command types and correct log messages, but `create` was missed:

| Method | Command Type (before) | Command Type (after) | Log Message (before) | Log Message (after) |
|---|---|---|---|---|
| `prevention.create` | `rule_create` | `prevention_create` | "Rule created on resource" | "Prevention created on resource" |
| `prevention.update` | `prevention_update` | *(no change)* | "Prevention updated on resource" | *(no change)* |
| `prevention.delete` | `prevention_delete` | *(no change)* | "Delete preventions" | *(no change)* |

## Why this matters

The "Rule created on resource" message appears in **control process logs** when prevention discovery controls run, alongside our own "Prevention" terminology. This is confusing for operators reviewing control logs — they see both "Rule" and "Prevention" terminology for the same concept.

The deprecated `turbot.rule` getter is left unchanged since it's deprecated and should use "Rule" terminology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)